### PR TITLE
SPIKE: `--disable=VIDEO`

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,3 +1,4 @@
 [
-  "NATIVE"
+  "NATIVE",
+  "VIDEO"
 ]

--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -53,10 +53,6 @@ export const DEFAULT_PROCESSORS = {
       // populates imp.banner
       fn: fillBannerImp
     },
-    video: {
-      // populates imp.video
-      fn: fillVideoImp
-    },
     pbadslot: {
       // removes imp.ext.data.pbaslot if it's not a string
       // TODO: is this needed?
@@ -77,10 +73,6 @@ export const DEFAULT_PROCESSORS = {
     banner: {
       // sets banner response attributes if bidResponse.mediaType === BANNER
       fn: bannerResponseProcessor(),
-    },
-    video: {
-      // sets video response attributes if bidResponse.mediaType === VIDEO
-      fn: fillVideoResponse
     },
     props: {
       // sets base bidResponse properties common to all types of bids
@@ -120,6 +112,17 @@ if (FEATURES.NATIVE) {
     // populates bidResponse.native if bidResponse.mediaType === NATIVE
     fn: fillNativeResponse
   }
+}
+
+if (FEATURES.VIDEO) {
+  DEFAULT_PROCESSORS[IMP].video = {
+    // populates imp.video
+    fn: fillVideoImp
+  };
+  DEFAULT_PROCESSORS[BID_RESPONSE].video = {
+    // sets video response attributes if bidResponse.mediaType === VIDEO
+    fn: fillVideoResponse
+  };
 }
 
 function fpdFromTopLevelConfig(prop) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -654,7 +654,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     bid.meta = Object.assign({}, bid.meta, { brandId: rtbBid.brand_id });
   }
 
-  if (rtbBid.rtb.video) {
+  if (FEATURES.VIDEO && rtbBid.rtb[VIDEO]) {
     // shared video properties used for all 3 contexts
     Object.assign(bid, {
       width: rtbBid.rtb.video.player_width,
@@ -857,107 +857,109 @@ function bidToTag(bid) {
     }
   }
 
-  const videoMediaType = deepAccess(bid, `mediaTypes.${VIDEO}`);
-  const context = deepAccess(bid, 'mediaTypes.video.context');
+  if (FEATURES.VIDEO) {
+    const videoMediaType = deepAccess(bid, `mediaTypes.${VIDEO}`);
+    const context = deepAccess(bid, 'mediaTypes.video.context');
 
-  if (videoMediaType && context === 'adpod') {
-    tag.hb_source = 7;
-  } else {
-    tag.hb_source = 1;
-  }
-  if (bid.mediaType === VIDEO || videoMediaType) {
-    tag.ad_types.push(VIDEO);
-  }
-
-  // instream gets vastUrl, outstream gets vastXml
-  if (bid.mediaType === VIDEO || (videoMediaType && context !== 'outstream')) {
-    tag.require_asset_url = true;
-  }
-
-  if (bid.params.video) {
-    tag.video = {};
-    // place any valid video params on the tag
-    Object.keys(bid.params.video)
-      .filter(param => includes(VIDEO_TARGETING, param))
-      .forEach(param => {
-        switch (param) {
-          case 'context':
-          case 'playback_method':
-            let type = bid.params.video[param];
-            type = (isArray(type)) ? type[0] : type;
-            tag.video[param] = VIDEO_MAPPING[param][type];
-            break;
-          // Deprecating tags[].video.frameworks in favor of tags[].video_frameworks
-          case 'frameworks':
-            break;
-          default:
-            tag.video[param] = bid.params.video[param];
-        }
-      });
-
-    if (bid.params.video.frameworks && isArray(bid.params.video.frameworks)) {
-      tag['video_frameworks'] = bid.params.video.frameworks;
+    if (videoMediaType && context === 'adpod') {
+      tag.hb_source = 7;
+    } else {
+      tag.hb_source = 1;
     }
-  }
+    if (bid.mediaType === VIDEO || videoMediaType) {
+      tag.ad_types.push(VIDEO);
+    }
 
-  // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
-  if (videoMediaType) {
-    tag.video = tag.video || {};
-    Object.keys(videoMediaType)
-      .filter(param => includes(VIDEO_RTB_TARGETING, param))
-      .forEach(param => {
-        switch (param) {
-          case 'minduration':
-          case 'maxduration':
-            if (typeof tag.video[param] !== 'number') tag.video[param] = videoMediaType[param];
-            break;
-          case 'skip':
-            if (typeof tag.video['skippable'] !== 'boolean') tag.video['skippable'] = (videoMediaType[param] === 1);
-            break;
-          case 'skipafter':
-            if (typeof tag.video['skipoffset'] !== 'number') tag.video['skippoffset'] = videoMediaType[param];
-            break;
-          case 'playbackmethod':
-            if (typeof tag.video['playback_method'] !== 'number') {
-              let type = videoMediaType[param];
+    // instream gets vastUrl, outstream gets vastXml
+    if (bid.mediaType === VIDEO || (videoMediaType && context !== 'outstream')) {
+      tag.require_asset_url = true;
+    }
+
+    if (bid.params.video) {
+      tag.video = {};
+      // place any valid video params on the tag
+      Object.keys(bid.params.video)
+        .filter(param => includes(VIDEO_TARGETING, param))
+        .forEach(param => {
+          switch (param) {
+            case 'context':
+            case 'playback_method':
+              let type = bid.params.video[param];
               type = (isArray(type)) ? type[0] : type;
+              tag.video[param] = VIDEO_MAPPING[param][type];
+              break;
+            // Deprecating tags[].video.frameworks in favor of tags[].video_frameworks
+            case 'frameworks':
+              break;
+            default:
+              tag.video[param] = bid.params.video[param];
+          }
+        });
 
-              // we only support iab's options 1-4 at this time.
-              if (type >= 1 && type <= 4) {
-                tag.video['playback_method'] = type;
-              }
-            }
-            break;
-          case 'api':
-            if (!tag['video_frameworks'] && isArray(videoMediaType[param])) {
-              // need to read thru array; remove 6 (we don't support it), swap 4 <> 5 if found (to match our adserver mapping for these specific values)
-              let apiTmp = videoMediaType[param].map(val => {
-                let v = (val === 4) ? 5 : (val === 5) ? 4 : val;
+      if (bid.params.video.frameworks && isArray(bid.params.video.frameworks)) {
+        tag['video_frameworks'] = bid.params.video.frameworks;
+      }
+    }
 
-                if (v >= 1 && v <= 5) {
-                  return v;
+    // use IAB ORTB values if the corresponding values weren't already set by bid.params.video
+    if (videoMediaType) {
+      tag.video = tag.video || {};
+      Object.keys(videoMediaType)
+        .filter(param => includes(VIDEO_RTB_TARGETING, param))
+        .forEach(param => {
+          switch (param) {
+            case 'minduration':
+            case 'maxduration':
+              if (typeof tag.video[param] !== 'number') tag.video[param] = videoMediaType[param];
+              break;
+            case 'skip':
+              if (typeof tag.video['skippable'] !== 'boolean') tag.video['skippable'] = (videoMediaType[param] === 1);
+              break;
+            case 'skipafter':
+              if (typeof tag.video['skipoffset'] !== 'number') tag.video['skippoffset'] = videoMediaType[param];
+              break;
+            case 'playbackmethod':
+              if (typeof tag.video['playback_method'] !== 'number') {
+                let type = videoMediaType[param];
+                type = (isArray(type)) ? type[0] : type;
+
+                // we only support iab's options 1-4 at this time.
+                if (type >= 1 && type <= 4) {
+                  tag.video['playback_method'] = type;
                 }
-              }).filter(v => v);
-              tag['video_frameworks'] = apiTmp;
-            }
-            break;
+              }
+              break;
+            case 'api':
+              if (!tag['video_frameworks'] && isArray(videoMediaType[param])) {
+                // need to read thru array; remove 6 (we don't support it), swap 4 <> 5 if found (to match our adserver mapping for these specific values)
+                let apiTmp = videoMediaType[param].map(val => {
+                  let v = (val === 4) ? 5 : (val === 5) ? 4 : val;
 
-          case 'startdelay':
-          case 'placement':
-            const contextKey = 'context';
-            if (typeof tag.video[contextKey] !== 'number') {
-              const placement = videoMediaType['placement'];
-              const startdelay = videoMediaType['startdelay'];
-              const context = getContextFromPlacement(placement) || getContextFromStartDelay(startdelay);
-              tag.video[contextKey] = VIDEO_MAPPING[contextKey][context];
-            }
-            break;
-        }
-      });
-  }
+                  if (v >= 1 && v <= 5) {
+                    return v;
+                  }
+                }).filter(v => v);
+                tag['video_frameworks'] = apiTmp;
+              }
+              break;
 
-  if (bid.renderer) {
-    tag.video = Object.assign({}, tag.video, { custom_renderer_present: true });
+            case 'startdelay':
+            case 'placement':
+              const contextKey = 'context';
+              if (typeof tag.video[contextKey] !== 'number') {
+                const placement = videoMediaType['placement'];
+                const startdelay = videoMediaType['startdelay'];
+                const context = getContextFromPlacement(placement) || getContextFromStartDelay(startdelay);
+                tag.video[contextKey] = VIDEO_MAPPING[contextKey][context];
+              }
+              break;
+          }
+        });
+    }
+
+    if (bid.renderer) {
+      tag.video = Object.assign({}, tag.video, { custom_renderer_present: true });
+    }
   }
 
   if (bid.params.frameworks && isArray(bid.params.frameworks)) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -654,7 +654,8 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     bid.meta = Object.assign({}, bid.meta, { brandId: rtbBid.brand_id });
   }
 
-  if (FEATURES.VIDEO && rtbBid.rtb[VIDEO]) {
+  // if (FEATURES.VIDEO && rtbBid.rtb[VIDEO]) {
+  if (rtbBid.rtb[VIDEO]) {
     // shared video properties used for all 3 contexts
     Object.assign(bid, {
       width: rtbBid.rtb.video.player_width,

--- a/modules/sizeMappingV2.js
+++ b/modules/sizeMappingV2.js
@@ -182,7 +182,7 @@ export function checkAdUnitSetupHook(adUnits) {
       }
     }
 
-    if (mediaTypes.video) {
+    if (FEATURES.VIDEO && mediaTypes.video) {
       if (mediaTypes.video.playerSize) {
         // Ad unit is using 'mediaTypes.video.playerSize' instead of the new property 'sizeConfig'. Apply the old checks!
         validatedVideo = validatedBanner ? adUnitSetupChecks.validateVideoMediaType(validatedBanner) : adUnitSetupChecks.validateVideoMediaType(adUnit);

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -443,7 +443,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
 
 function getSupportedMediaTypes(bidderCode) {
   let supportedMediaTypes = [];
-  if (includes(adapterManager.videoAdapters, bidderCode)) supportedMediaTypes.push('video');
+  if (FEATURES.VIDEO && includes(adapterManager.videoAdapters, bidderCode)) supportedMediaTypes.push('video');
   if (FEATURES.NATIVE && includes(nativeAdapters, bidderCode)) supportedMediaTypes.push('native');
   return supportedMediaTypes;
 }
@@ -455,7 +455,7 @@ adapterManager.registerBidAdapter = function (bidAdapter, bidderCode, {supported
     if (typeof bidAdapter.callBids === 'function') {
       _bidderRegistry[bidderCode] = bidAdapter;
 
-      if (includes(supportedMediaTypes, 'video')) {
+      if (FEATURES.VIDEO && includes(supportedMediaTypes, 'video')) {
         adapterManager.videoAdapters.push(bidderCode);
       }
       if (FEATURES.NATIVE && includes(supportedMediaTypes, 'native')) {

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -599,7 +599,7 @@ export function isValid(adUnitCode, bid, {index = auctionManager.index} = {}) {
     logError(errorMessage('Native bid missing some required properties.'));
     return false;
   }
-  if (bid.mediaType === 'video' && !isValidVideoBid(bid, {index})) {
+  if (FEATURES.VIDEO && bid.mediaType === 'video' && !isValidVideoBid(bid, {index})) {
     logError(errorMessage(`Video bid does not have required vastUrl or renderer property`));
     return false;
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -462,7 +462,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
     handleBidResponse(adUnitCode, bid, (done) => {
       let bidResponse = getPreparedBidForAuction(bid);
 
-      if (bidResponse.mediaType === VIDEO) {
+      if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
         tryAddVideoBid(auctionInstance, bidResponse, done);
       } else {
         if (FEATURES.NATIVE && bidResponse.native != null && typeof bidResponse.native === 'object') {
@@ -771,7 +771,7 @@ function setupBidTargeting(bidObject) {
  */
 export function getMediaTypeGranularity(mediaType, mediaTypes, mediaTypePriceGranularity) {
   if (mediaType && mediaTypePriceGranularity) {
-    if (mediaType === VIDEO) {
+    if (FEATURES.VIDEO && mediaType === VIDEO) {
       const context = deepAccess(mediaTypes, `${VIDEO}.context`, 'instream');
       if (mediaTypePriceGranularity[`${VIDEO}-${context}`]) {
         return mediaTypePriceGranularity[`${VIDEO}-${context}`];

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1385,63 +1385,65 @@ describe('auctionmanager.js', function () {
   }
 
   describe('getMediaTypeGranularity', function () {
-    it('video', function () {
-      let mediaTypes = { video: {id: '1'} };
+    if (FEATURES.VIDEO) {
+      it('video', function () {
+        let mediaTypes = { video: {id: '1'} };
 
-      // mediaType is video and video.context is undefined
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        // mediaType is video and video.context is undefined
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      expect(getMediaTypeGranularity('video', {}, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
-      ``
-      expect(getMediaTypeGranularity('video', undefined, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        expect(getMediaTypeGranularity('video', {}, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
+        ``
+        expect(getMediaTypeGranularity('video', undefined, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      // also when mediaTypes.video is undefined
-      mediaTypes = { banner: {} };
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        // also when mediaTypes.video is undefined
+        mediaTypes = { banner: {} };
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      // also when mediaTypes is undefined
-      expect(getMediaTypeGranularity('video', {}, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
-    });
+        // also when mediaTypes is undefined
+        expect(getMediaTypeGranularity('video', {}, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
+      });
 
-    it('video-outstream', function () {
-      let mediaTypes = { video: { context: 'outstream' } };
+      it('video-outstream', function () {
+        let mediaTypes = { video: { context: 'outstream' } };
 
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        'banner': 'low', 'video': 'medium', 'video-outstream': 'high'
-      })).to.equal('high');
-    });
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          'banner': 'low', 'video': 'medium', 'video-outstream': 'high'
+        })).to.equal('high');
+      });
 
-    it('video-instream', function () {
-      let mediaTypes = { video: { context: 'instream' } };
+      it('video-instream', function () {
+        let mediaTypes = { video: { context: 'instream' } };
 
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low', video: 'medium', 'video-instream': 'high'
-      })).to.equal('high');
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low', video: 'medium', 'video-instream': 'high'
+        })).to.equal('high');
 
-      // fall back to video if video-instream not found
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low', video: 'medium'
-      })).to.equal('medium');
+        // fall back to video if video-instream not found
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low', video: 'medium'
+        })).to.equal('medium');
 
-      expect(getMediaTypeGranularity('video', {mediaTypes: {banner: {}}}, {
-        banner: 'low', video: 'medium'
-      })).to.equal('medium');
-    });
+        expect(getMediaTypeGranularity('video', {mediaTypes: {banner: {}}}, {
+          banner: 'low', video: 'medium'
+        })).to.equal('medium');
+      });
+    }
 
     it('native', function () {
       expect(getMediaTypeGranularity('native', {native: {}}, {
@@ -1543,34 +1545,36 @@ describe('auctionmanager.js', function () {
       });
     })
 
-    it('should call auction done after prebid cache is complete for mediaType video', function() {
-      bids[0].mediaType = 'video';
-      let bids1 = [mockBid({ bidderCode: BIDDER_CODE1 })];
+    if (FEATURES.VIDEO) {
+      it('should call auction done after prebid cache is complete for mediaType video', function() {
+        bids[0].mediaType = 'video';
+        let bids1 = [mockBid({ bidderCode: BIDDER_CODE1 })];
 
-      let opts = {
-        mediaType: {
-          video: {
-            context: 'instream',
-            playerSize: [640, 480],
-          },
-        }
-      };
-      bidRequests = [
-        mockBidRequest(bids[0], opts),
-        mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
-      ];
+        let opts = {
+          mediaType: {
+            video: {
+              context: 'instream',
+              playerSize: [640, 480],
+            },
+          }
+        };
+        bidRequests = [
+          mockBidRequest(bids[0], opts),
+          mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
+        ];
 
-      let cbs = auctionCallbacks(doneSpy, auction);
-      cbs.addBidResponse.call(bidRequests[0], ADUNIT_CODE, bids[0]);
-      cbs.adapterDone.call(bidRequests[0]);
-      cbs.addBidResponse.call(bidRequests[1], ADUNIT_CODE1, bids1[0]);
-      cbs.adapterDone.call(bidRequests[1]);
-      assert.equal(doneSpy.callCount, 0);
-      const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
-      const responseBody = `{"responses":[{"uuid":"${uuid}"}]}`;
-      server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
-      assert.equal(doneSpy.callCount, 1);
-    });
+        let cbs = auctionCallbacks(doneSpy, auction);
+        cbs.addBidResponse.call(bidRequests[0], ADUNIT_CODE, bids[0]);
+        cbs.adapterDone.call(bidRequests[0]);
+        cbs.addBidResponse.call(bidRequests[1], ADUNIT_CODE1, bids1[0]);
+        cbs.adapterDone.call(bidRequests[1]);
+        assert.equal(doneSpy.callCount, 0);
+        const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
+        const responseBody = `{"responses":[{"uuid":"${uuid}"}]}`;
+        server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
+        assert.equal(doneSpy.callCount, 1);
+      });
+    }
 
     it('should convert cpm to number', () => {
       auction.addBidReceived = sinon.spy();

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -195,9 +195,12 @@ describe('AppNexusAdapter', function () {
         transactionId: '04f2659e-c005-4eb1-a57c-fa93145e3843'
       }];
 
-      let types = ['banner', 'video'];
+      let types = ['banner'];
       if (FEATURES.NATIVE) {
         types.push('native');
+      }
+      if (FEATURES.VIDEO) {
+        types.push('video');
       }
 
       types.forEach(type => {
@@ -228,17 +231,19 @@ describe('AppNexusAdapter', function () {
       expect(payload.tags[0].ad_types).to.not.exist;
     });
 
-    it('should populate the ad_types array on outstream requests', function () {
-      const bidRequest = Object.assign({}, bidRequests[0]);
-      bidRequest.mediaTypes = {};
-      bidRequest.mediaTypes.video = { context: 'outstream' };
+    if (FEATURES.VIDEO) {
+      it('should populate the ad_types array on outstream requests', function () {
+        const bidRequest = Object.assign({}, bidRequests[0]);
+        bidRequest.mediaTypes = {};
+        bidRequest.mediaTypes.video = { context: 'outstream' };
 
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
+        const request = spec.buildRequests([bidRequest]);
+        const payload = JSON.parse(request.data);
 
-      expect(payload.tags[0].ad_types).to.deep.equal(['video']);
-      expect(payload.tags[0].hb_source).to.deep.equal(1);
-    });
+        expect(payload.tags[0].ad_types).to.deep.equal(['video']);
+        expect(payload.tags[0].hb_source).to.deep.equal(1);
+      });
+    }
 
     it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
@@ -246,105 +251,107 @@ describe('AppNexusAdapter', function () {
       expect(request.method).to.equal('POST');
     });
 
-    it('should attach valid video params to the tag', function () {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
+    if (FEATURES.VIDEO) {
+      it('should attach valid video params to the tag', function () {
+        let bidRequest = Object.assign({},
+          bidRequests[0],
+          {
+            params: {
+              placementId: '10433394',
+              video: {
+                id: 123,
+                minduration: 100,
+                foobar: 'invalid'
+              }
+            }
+          }
+        );
+
+        const request = spec.buildRequests([bidRequest]);
+        const payload = JSON.parse(request.data);
+        expect(payload.tags[0].video).to.deep.equal({
+          id: 123,
+          minduration: 100
+        });
+        expect(payload.tags[0].hb_source).to.deep.equal(1);
+      });
+
+      it('should include ORTB video values when video params were not set', function () {
+        let bidRequest = deepClone(bidRequests[0]);
+        bidRequest.params = {
+          placementId: '1234235',
+          video: {
+            skippable: true,
+            playback_method: ['auto_play_sound_off', 'auto_play_sound_unknown'],
+            context: 'outstream'
+          }
+        };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [640, 480],
+            context: 'outstream',
+            mimes: ['video/mp4'],
+            skip: 0,
+            minduration: 5,
+            api: [1, 5, 6],
+            playbackmethod: [2, 4]
+          }
+        };
+
+        const request = spec.buildRequests([bidRequest]);
+        const payload = JSON.parse(request.data);
+
+        expect(payload.tags[0].video).to.deep.equal({
+          minduration: 5,
+          playback_method: 2,
+          skippable: true,
+          context: 4
+        });
+        expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
+      });
+
+      it('should add video property when adUnit includes a renderer', function () {
+        const videoData = {
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              mimes: ['video/mp4']
+            }
+          },
           params: {
             placementId: '10433394',
             video: {
-              id: 123,
-              minduration: 100,
-              foobar: 'invalid'
+              skippable: true,
+              playback_method: ['auto_play_sound_off']
             }
           }
-        }
-      );
+        };
 
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-      expect(payload.tags[0].video).to.deep.equal({
-        id: 123,
-        minduration: 100
-      });
-      expect(payload.tags[0].hb_source).to.deep.equal(1);
-    });
+        let bidRequest1 = deepClone(bidRequests[0]);
+        bidRequest1 = Object.assign({}, bidRequest1, videoData, {
+          renderer: {
+            url: 'https://test.renderer.url',
+            render: function () { }
+          }
+        });
 
-    it('should include ORTB video values when video params were not set', function () {
-      let bidRequest = deepClone(bidRequests[0]);
-      bidRequest.params = {
-        placementId: '1234235',
-        video: {
+        let bidRequest2 = deepClone(bidRequests[0]);
+        bidRequest2.adUnitCode = 'adUnit_code_2';
+        bidRequest2 = Object.assign({}, bidRequest2, videoData);
+
+        const request = spec.buildRequests([bidRequest1, bidRequest2]);
+        const payload = JSON.parse(request.data);
+        expect(payload.tags[0].video).to.deep.equal({
           skippable: true,
-          playback_method: ['auto_play_sound_off', 'auto_play_sound_unknown'],
-          context: 'outstream'
-        }
-      };
-      bidRequest.mediaTypes = {
-        video: {
-          playerSize: [640, 480],
-          context: 'outstream',
-          mimes: ['video/mp4'],
-          skip: 0,
-          minduration: 5,
-          api: [1, 5, 6],
-          playbackmethod: [2, 4]
-        }
-      };
-
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-
-      expect(payload.tags[0].video).to.deep.equal({
-        minduration: 5,
-        playback_method: 2,
-        skippable: true,
-        context: 4
+          playback_method: 2,
+          custom_renderer_present: true
+        });
+        expect(payload.tags[1].video).to.deep.equal({
+          skippable: true,
+          playback_method: 2
+        });
       });
-      expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
-    });
-
-    it('should add video property when adUnit includes a renderer', function () {
-      const videoData = {
-        mediaTypes: {
-          video: {
-            context: 'outstream',
-            mimes: ['video/mp4']
-          }
-        },
-        params: {
-          placementId: '10433394',
-          video: {
-            skippable: true,
-            playback_method: ['auto_play_sound_off']
-          }
-        }
-      };
-
-      let bidRequest1 = deepClone(bidRequests[0]);
-      bidRequest1 = Object.assign({}, bidRequest1, videoData, {
-        renderer: {
-          url: 'https://test.renderer.url',
-          render: function () { }
-        }
-      });
-
-      let bidRequest2 = deepClone(bidRequests[0]);
-      bidRequest2.adUnitCode = 'adUnit_code_2';
-      bidRequest2 = Object.assign({}, bidRequest2, videoData);
-
-      const request = spec.buildRequests([bidRequest1, bidRequest2]);
-      const payload = JSON.parse(request.data);
-      expect(payload.tags[0].video).to.deep.equal({
-        skippable: true,
-        playback_method: 2,
-        custom_renderer_present: true
-      });
-      expect(payload.tags[1].video).to.deep.equal({
-        skippable: true,
-        playback_method: 2
-      });
-    });
+    }
 
     it('should attach valid user params to the tag', function () {
       let bidRequest = Object.assign({},
@@ -581,27 +588,29 @@ describe('AppNexusAdapter', function () {
       expect(payload3.tags.length).to.equal(15);
     });
 
-    it('should contain hb_source value for adpod', function () {
-      let bidRequest = Object.assign({},
-        bidRequests[0],
-        {
-          params: { placementId: '14542875' }
-        },
-        {
-          mediaTypes: {
-            video: {
-              context: 'adpod',
-              playerSize: [640, 480],
-              adPodDurationSec: 300,
-              durationRangeSec: [15, 30],
+    if (FEATURES.VIDEO) {
+      it('should contain hb_source value for adpod', function () {
+        let bidRequest = Object.assign({},
+          bidRequests[0],
+          {
+            params: { placementId: '14542875' }
+          },
+          {
+            mediaTypes: {
+              video: {
+                context: 'adpod',
+                playerSize: [640, 480],
+                adPodDurationSec: 300,
+                durationRangeSec: [15, 30],
+              }
             }
           }
-        }
-      );
-      const request = spec.buildRequests([bidRequest])[0];
-      const payload = JSON.parse(request.data);
-      expect(payload.tags[0].hb_source).to.deep.equal(7);
-    });
+        );
+        const request = spec.buildRequests([bidRequest])[0];
+        const payload = JSON.parse(request.data);
+        expect(payload.tags[0].hb_source).to.deep.equal(7);
+      });
+    }
 
     it('should contain hb_source value for other media', function () {
       let bidRequest = Object.assign({},
@@ -1484,116 +1493,118 @@ describe('AppNexusAdapter', function () {
       expect(result.length).to.equal(0);
     });
 
-    it('handles outstream video responses', function () {
-      let response = {
-        'tags': [{
-          'uuid': '84ab500420319d',
-          'ads': [{
-            'ad_type': 'video',
-            'cpm': 0.500000,
-            'notify_url': 'imptracker.com',
-            'rtb': {
-              'video': {
-                'content': '<!-- VAST Creative -->'
-              }
-            },
-            'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+    if (FEATURES.VIDEO) {
+      it('handles outstream video responses', function () {
+        let response = {
+          'tags': [{
+            'uuid': '84ab500420319d',
+            'ads': [{
+              'ad_type': 'video',
+              'cpm': 0.500000,
+              'notify_url': 'imptracker.com',
+              'rtb': {
+                'video': {
+                  'content': '<!-- VAST Creative -->'
+                }
+              },
+              'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+            }]
           }]
-        }]
-      };
-      let bidderRequest = {
-        bids: [{
-          bidId: '84ab500420319d',
-          adUnitCode: 'code',
-          mediaTypes: {
-            video: {
-              context: 'outstream'
-            }
-          }
-        }]
-      }
-
-      let result = spec.interpretResponse({ body: response }, { bidderRequest });
-      expect(result[0]).to.have.property('vastXml');
-      expect(result[0]).to.have.property('vastImpUrl');
-      expect(result[0]).to.have.property('mediaType', 'video');
-    });
-
-    it('handles instream video responses', function () {
-      let response = {
-        'tags': [{
-          'uuid': '84ab500420319d',
-          'ads': [{
-            'ad_type': 'video',
-            'cpm': 0.500000,
-            'notify_url': 'imptracker.com',
-            'rtb': {
-              'video': {
-                'asset_url': 'https://sample.vastURL.com/here/vid'
+        };
+        let bidderRequest = {
+          bids: [{
+            bidId: '84ab500420319d',
+            adUnitCode: 'code',
+            mediaTypes: {
+              video: {
+                context: 'outstream'
               }
-            },
-            'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
-          }]
-        }]
-      };
-      let bidderRequest = {
-        bids: [{
-          bidId: '84ab500420319d',
-          adUnitCode: 'code',
-          mediaTypes: {
-            video: {
-              context: 'instream'
-            }
-          }
-        }]
-      }
-
-      let result = spec.interpretResponse({ body: response }, { bidderRequest });
-      expect(result[0]).to.have.property('vastUrl');
-      expect(result[0]).to.have.property('vastImpUrl');
-      expect(result[0]).to.have.property('mediaType', 'video');
-    });
-
-    it('handles adpod responses', function () {
-      let response = {
-        'tags': [{
-          'uuid': '84ab500420319d',
-          'ads': [{
-            'ad_type': 'video',
-            'brand_category_id': 10,
-            'cpm': 0.500000,
-            'notify_url': 'imptracker.com',
-            'rtb': {
-              'video': {
-                'asset_url': 'https://sample.vastURL.com/here/adpod',
-                'duration_ms': 30000,
-              }
-            },
-            'viewability': {
-              'config': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
             }
           }]
-        }]
-      };
+        }
 
-      let bidderRequest = {
-        bids: [{
-          bidId: '84ab500420319d',
-          adUnitCode: 'code',
-          mediaTypes: {
-            video: {
-              context: 'adpod'
+        let result = spec.interpretResponse({ body: response }, { bidderRequest });
+        expect(result[0]).to.have.property('vastXml');
+        expect(result[0]).to.have.property('vastImpUrl');
+        expect(result[0]).to.have.property('mediaType', 'video');
+      });
+
+      it('handles instream video responses', function () {
+        let response = {
+          'tags': [{
+            'uuid': '84ab500420319d',
+            'ads': [{
+              'ad_type': 'video',
+              'cpm': 0.500000,
+              'notify_url': 'imptracker.com',
+              'rtb': {
+                'video': {
+                  'asset_url': 'https://sample.vastURL.com/here/vid'
+                }
+              },
+              'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+            }]
+          }]
+        };
+        let bidderRequest = {
+          bids: [{
+            bidId: '84ab500420319d',
+            adUnitCode: 'code',
+            mediaTypes: {
+              video: {
+                context: 'instream'
+              }
             }
-          }
-        }]
-      };
-      bfStub.returns('1');
+          }]
+        }
 
-      let result = spec.interpretResponse({ body: response }, { bidderRequest });
-      expect(result[0]).to.have.property('vastUrl');
-      expect(result[0].video.context).to.equal('adpod');
-      expect(result[0].video.durationSeconds).to.equal(30);
-    });
+        let result = spec.interpretResponse({ body: response }, { bidderRequest });
+        expect(result[0]).to.have.property('vastUrl');
+        expect(result[0]).to.have.property('vastImpUrl');
+        expect(result[0]).to.have.property('mediaType', 'video');
+      });
+
+      it('handles adpod responses', function () {
+        let response = {
+          'tags': [{
+            'uuid': '84ab500420319d',
+            'ads': [{
+              'ad_type': 'video',
+              'brand_category_id': 10,
+              'cpm': 0.500000,
+              'notify_url': 'imptracker.com',
+              'rtb': {
+                'video': {
+                  'asset_url': 'https://sample.vastURL.com/here/adpod',
+                  'duration_ms': 30000,
+                }
+              },
+              'viewability': {
+                'config': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+              }
+            }]
+          }]
+        };
+
+        let bidderRequest = {
+          bids: [{
+            bidId: '84ab500420319d',
+            adUnitCode: 'code',
+            mediaTypes: {
+              video: {
+                context: 'adpod'
+              }
+            }
+          }]
+        };
+        bfStub.returns('1');
+
+        let result = spec.interpretResponse({ body: response }, { bidderRequest });
+        expect(result[0]).to.have.property('vastUrl');
+        expect(result[0].video.context).to.equal('adpod');
+        expect(result[0].video.durationSeconds).to.equal(30);
+      });
+    }
 
     if (FEATURES.NATIVE) {
       it('handles native responses', function () {
@@ -1647,59 +1658,63 @@ describe('AppNexusAdapter', function () {
       });
     }
 
-    it('supports configuring outstream renderers', function () {
-      const outstreamResponse = deepClone(response);
-      outstreamResponse.tags[0].ads[0].rtb.video = {};
-      outstreamResponse.tags[0].ads[0].renderer_url = 'renderer.js';
+    if (FEATURES.VIDEO) {
+      it('supports configuring outstream renderers', function () {
+        const outstreamResponse = deepClone(response);
+        outstreamResponse.tags[0].ads[0].rtb.video = {};
+        outstreamResponse.tags[0].ads[0].renderer_url = 'renderer.js';
 
-      const bidderRequest = {
-        bids: [{
-          bidId: '3db3773286ee59',
-          renderer: {
-            options: {
-              adText: 'configured'
+        const bidderRequest = {
+          bids: [{
+            bidId: '3db3773286ee59',
+            renderer: {
+              options: {
+                adText: 'configured'
+              }
+            },
+            mediaTypes: {
+              video: {
+                context: 'outstream'
+              }
             }
-          },
-          mediaTypes: {
-            video: {
-              context: 'outstream'
+          }]
+        };
+
+        const result = spec.interpretResponse({ body: outstreamResponse }, { bidderRequest });
+        expect(result[0].renderer.config).to.deep.equal(
+          bidderRequest.bids[0].renderer.options
+        );
+      });
+    }
+
+    if (FEATURES.VIDEO) {
+      it('should add deal_priority and deal_code', function () {
+        let responseWithDeal = deepClone(response);
+        responseWithDeal.tags[0].ads[0].ad_type = 'video';
+        responseWithDeal.tags[0].ads[0].deal_priority = 5;
+        responseWithDeal.tags[0].ads[0].deal_code = '123';
+        responseWithDeal.tags[0].ads[0].rtb.video = {
+          duration_ms: 1500,
+          player_width: 640,
+          player_height: 340,
+        };
+
+        let bidderRequest = {
+          bids: [{
+            bidId: '3db3773286ee59',
+            adUnitCode: 'code',
+            mediaTypes: {
+              video: {
+                context: 'adpod'
+              }
             }
-          }
-        }]
-      };
-
-      const result = spec.interpretResponse({ body: outstreamResponse }, { bidderRequest });
-      expect(result[0].renderer.config).to.deep.equal(
-        bidderRequest.bids[0].renderer.options
-      );
-    });
-
-    it('should add deal_priority and deal_code', function () {
-      let responseWithDeal = deepClone(response);
-      responseWithDeal.tags[0].ads[0].ad_type = 'video';
-      responseWithDeal.tags[0].ads[0].deal_priority = 5;
-      responseWithDeal.tags[0].ads[0].deal_code = '123';
-      responseWithDeal.tags[0].ads[0].rtb.video = {
-        duration_ms: 1500,
-        player_width: 640,
-        player_height: 340,
-      };
-
-      let bidderRequest = {
-        bids: [{
-          bidId: '3db3773286ee59',
-          adUnitCode: 'code',
-          mediaTypes: {
-            video: {
-              context: 'adpod'
-            }
-          }
-        }]
-      }
-      let result = spec.interpretResponse({ body: responseWithDeal }, { bidderRequest });
-      expect(Object.keys(result[0].appnexus)).to.include.members(['buyerMemberId', 'dealPriority', 'dealCode']);
-      expect(result[0].video.dealTier).to.equal(5);
-    });
+          }]
+        }
+        let result = spec.interpretResponse({ body: responseWithDeal }, { bidderRequest });
+        expect(Object.keys(result[0].appnexus)).to.include.members(['buyerMemberId', 'dealPriority', 'dealCode']);
+        expect(result[0].video.dealTier).to.equal(5);
+      });
+    }
 
     it('should add advertiser id', function () {
       let responseAdvertiserId = deepClone(response);

--- a/test/spec/modules/big-richmediaBidAdapter_spec.js
+++ b/test/spec/modules/big-richmediaBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { auctionManager } from 'src/auctionManager.js';
 import * as bidderFactory from 'src/adapters/bidderFactory.js';
 import { config } from 'src/config.js';
 import { deepClone } from 'src/utils.js';
+import features from 'core-js-pure/features';
 
 describe('bigRichMediaAdapterTests', function () {
   before(function () {
@@ -92,40 +93,42 @@ describe('bigRichMediaAdapterTests', function () {
       expect(payload.tags[0].sizes).to.have.lengthOf(3);
     });
 
-    it('should build video bid request', function() {
-      const bidRequest = deepClone(bidRequests[0]);
-      bidRequest.params = {
-        placementId: '1234235',
-        video: {
-          skippable: true,
-          playback_method: ['auto_play_sound_off', 'auto_play_sound_unknown'],
-          context: 'outstream',
-          format: 'sticky-top'
-        }
-      };
-      bidRequest.mediaTypes = {
-        video: {
-          playerSize: [640, 480],
-          context: 'outstream',
-          mimes: ['video/mp4'],
-          skip: 0,
+    if (FEATURES.VIDEO) {
+      it('should build video bid request', function() {
+        const bidRequest = deepClone(bidRequests[0]);
+        bidRequest.params = {
+          placementId: '1234235',
+          video: {
+            skippable: true,
+            playback_method: ['auto_play_sound_off', 'auto_play_sound_unknown'],
+            context: 'outstream',
+            format: 'sticky-top'
+          }
+        };
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [640, 480],
+            context: 'outstream',
+            mimes: ['video/mp4'],
+            skip: 0,
+            minduration: 5,
+            api: [1, 5, 6],
+            playbackmethod: [2, 4]
+          }
+        };
+
+        const request = spec.buildRequests([bidRequest]);
+        const payload = JSON.parse(request.data);
+
+        expect(payload.tags[0].video).to.deep.equal({
           minduration: 5,
-          api: [1, 5, 6],
-          playbackmethod: [2, 4]
-        }
-      };
-
-      const request = spec.buildRequests([bidRequest]);
-      const payload = JSON.parse(request.data);
-
-      expect(payload.tags[0].video).to.deep.equal({
-        minduration: 5,
-        playback_method: 2,
-        skippable: true,
-        context: 4
+          playback_method: 2,
+          skippable: true,
+          context: 4
+        });
+        expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
       });
-      expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
-    });
+    }
   });
 
   describe('interpretResponse', function () {
@@ -227,42 +230,44 @@ describe('bigRichMediaAdapterTests', function () {
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
     });
 
-    it('handles outstream video responses', function () {
-      const response = {
-        'tags': [{
-          'uuid': '84ab500420319d',
-          'ads': [{
-            'ad_type': 'video',
-            'cpm': 0.500000,
-            'notify_url': 'imptracker.com',
-            'rtb': {
-              'video': {
-                'content': '<!-- VAST Creative -->'
-              }
-            },
-            'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+    if (FEATURES.VIDEO) {
+      it('handles outstream video responses', function () {
+        const response = {
+          'tags': [{
+            'uuid': '84ab500420319d',
+            'ads': [{
+              'ad_type': 'video',
+              'cpm': 0.500000,
+              'notify_url': 'imptracker.com',
+              'rtb': {
+                'video': {
+                  'content': '<!-- VAST Creative -->'
+                }
+              },
+              'javascriptTrackers': '<script type=\'text/javascript\' async=\'true\' src=\'https://cdn.adnxs.com/v/s/152/trk.js#v;vk=appnexus.com-omid;tv=native1-18h;dom_id=%native_dom_id%;st=0;d=1x1;vc=iab;vid_ccr=1;tag_id=13232354;cb=https%3A%2F%2Fams1-ib.adnxs.com%2Fvevent%3Freferrer%3Dhttps253A%252F%252Ftestpages-pmahe.tp.adnxs.net%252F01_basic_single%26e%3DwqT_3QLNB6DNAwAAAwDWAAUBCLfl_-MFEMStk8u3lPTjRxih88aF0fq_2QsqNgkAAAECCCRAEQEHEAAAJEAZEQkAIREJACkRCQAxEQmoMOLRpwY47UhA7UhIAlCDy74uWJzxW2AAaM26dXjzjwWAAQGKAQNVU0SSAQEG8FCYAQGgAQGoAQGwAQC4AQHAAQTIAQLQAQDYAQDgAQDwAQCKAjt1ZignYScsIDI1Mjk4ODUsIDE1NTE4ODkwNzkpO3VmKCdyJywgOTc0OTQ0MDM2HgDwjZIC8QEha0RXaXBnajgtTHdLRUlQTHZpNFlBQ0NjOFZzd0FEZ0FRQVJJN1VoUTR0R25CbGdBWU1rR2FBQndMSGlrTDRBQlVvZ0JwQy1RQVFHWUFRR2dBUUdvQVFPd0FRQzVBZk90YXFRQUFDUkF3UUh6cldxa0FBQWtRTWtCbWo4dDA1ZU84VF9aQVFBQUEBAyRQQV80QUVBOVFFAQ4sQW1BSUFvQUlBdFFJBRAAdg0IeHdBSUF5QUlBNEFJQTZBSUEtQUlBZ0FNQm1BTUJxQVAFzIh1Z01KUVUxVE1UbzBNekl3NEFPVENBLi6aAmEhUXcxdGNRagUoEfQkblBGYklBUW9BRAl8AEEBqAREbzJEABRRSk1JU1EBGwRBQQGsAFURDAxBQUFXHQzwWNgCAOACrZhI6gIzaHR0cDovL3Rlc3RwYWdlcy1wbWFoZS50cC5hZG54cy5uZXQvMDFfYmFzaWNfc2luZ2xl8gITCg9DVVNUT01fTU9ERUxfSUQSAPICGgoWMhYAPExFQUZfTkFNRRIA8gIeCho2HQAIQVNUAT7wnElGSUVEEgCAAwCIAwGQAwCYAxegAwGqAwDAA-CoAcgDANgD8ao-4AMA6AMA-AMBgAQAkgQNL3V0L3YzL3ByZWJpZJgEAKIECjEwLjIuMTIuMzioBIqpB7IEDggAEAEYACAAKAAwADgCuAQAwAQAyAQA0gQOOTMyNSNBTVMxOjQzMjDaBAIIAeAEAfAEg8u-LogFAZgFAKAF______8BAxgBwAUAyQUABQEU8D_SBQkJBQt8AAAA2AUB4AUB8AWZ9CH6BQQIABAAkAYBmAYAuAYAwQYBITAAAPA_yAYA2gYWChAAOgEAGBAAGADgBgw.%26s%3D971dce9d49b6bee447c8a58774fb30b40fe98171;ts=1551889079;cet=0;cecb=\'></script>'
+            }]
           }]
-        }]
-      };
-      const bidderRequest = {
-        bids: [{
-          bidId: '84ab500420319d',
-          adUnitCode: 'code',
-          mediaTypes: {
-            video: {
-              context: 'outstream'
+        };
+        const bidderRequest = {
+          bids: [{
+            bidId: '84ab500420319d',
+            adUnitCode: 'code',
+            mediaTypes: {
+              video: {
+                context: 'outstream'
+              }
             }
-          }
-        }]
-      }
+          }]
+        }
 
-      const result = spec.interpretResponse({ body: response }, {bidderRequest});
-      expect(result[0]).not.to.have.property('vastXml');
-      expect(result[0]).not.to.have.property('vastUrl');
-      expect(result[0]).to.have.property('width', 1);
-      expect(result[0]).to.have.property('height', 1);
-      expect(result[0]).to.have.property('mediaType', 'banner');
-    });
+        const result = spec.interpretResponse({ body: response }, {bidderRequest});
+        expect(result[0]).not.to.have.property('vastXml');
+        expect(result[0]).not.to.have.property('vastUrl');
+        expect(result[0]).to.have.property('width', 1);
+        expect(result[0]).to.have.property('height', 1);
+        expect(result[0]).to.have.property('mediaType', 'banner');
+      });
+    }
   });
 
   describe('getUserSyncs', function() {

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -278,12 +278,6 @@ describe('Improve Digital Adapter Tests', function () {
               placementId: 1053688,
             }
           },
-          video: {
-            placement: OUTSTREAM_TYPE,
-            w: 640,
-            h: 480,
-            mimes: ['video/mp4'],
-          },
           banner: {
             format: [
               {w: 300, h: 250},
@@ -306,6 +300,16 @@ describe('Improve Digital Adapter Tests', function () {
           'assets': [
             sinon.match({'required': 1, 'data': {'type': 2}})
           ]
+        });
+      }
+      if (FEATURES.VIDEO) {
+        sinon.assert.match(payload.imp[0], {
+          video: {
+            placement: OUTSTREAM_TYPE,
+            w: 640,
+            h: 480,
+            mimes: ['video/mp4'],
+          },
         });
       }
     });
@@ -468,102 +472,104 @@ describe('Improve Digital Adapter Tests', function () {
       expect(payload.imp[0].video).to.not.exist;
     });
 
-    it('should add correct placement value for instream and outstream video', function () {
-      let bidRequest = deepClone(simpleBidRequest);
-      let payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
-      expect(payload.imp[0].video).to.not.exist;
+    if (FEATURES.VIDEO) {
+      it('should add correct placement value for instream and outstream video', function () {
+        let bidRequest = deepClone(simpleBidRequest);
+        let payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
+        expect(payload.imp[0].video).to.not.exist;
 
-      bidRequest = deepClone(simpleBidRequest);
-      bidRequest.mediaTypes = {
-        video: {
-          context: 'instream',
-          playerSize: [640, 480]
+        bidRequest = deepClone(simpleBidRequest);
+        bidRequest.mediaTypes = {
+          video: {
+            context: 'instream',
+            playerSize: [640, 480]
+          }
+        };
+        payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
+        expect(payload.imp[0].video.placement).to.exist.and.equal(1);
+        bidRequest.mediaTypes.video.context = 'outstream';
+        payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
+        expect(payload.imp[0].video.placement).to.exist.and.equal(3);
+      });
+
+      it('should set video params for instream', function() {
+        const bidRequest = deepClone(instreamBidRequest);
+        delete bidRequest.mediaTypes.video.playerSize;
+        const videoParams = {
+          mimes: ['video/mp4'],
+          skip: 1,
+          skipmin: 5,
+          skipafter: 30,
+          minduration: 15,
+          maxduration: 60,
+          startdelay: 5,
+          minbitrate: 500,
+          maxbitrate: 2000,
+          w: 1024,
+          h: 640,
+          placement: INSTREAM_TYPE,
+        };
+        bidRequest.params.video = videoParams;
+        const request = spec.buildRequests([bidRequest], bidderRequest)[0];
+        const payload = JSON.parse(request.data);
+        expect(payload.imp[0].video).to.deep.equal(videoParams);
+      });
+
+      it('should set video playerSize over video params', () => {
+        const bidRequest = deepClone(instreamBidRequest);
+        bidRequest.params.video = {
+          w: 1024, h: 640
         }
-      };
-      payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
-      expect(payload.imp[0].video.placement).to.exist.and.equal(1);
-      bidRequest.mediaTypes.video.context = 'outstream';
-      payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequest)[0].data);
-      expect(payload.imp[0].video.placement).to.exist.and.equal(3);
-    });
+        const request = spec.buildRequests([bidRequest], bidderRequest)[0];
+        const payload = JSON.parse(request.data);
+        expect(payload.imp[0].video.h).equal(480);
+        expect(payload.imp[0].video.w).equal(640);
+      });
 
-    it('should set video params for instream', function() {
-      const bidRequest = deepClone(instreamBidRequest);
-      delete bidRequest.mediaTypes.video.playerSize;
-      const videoParams = {
-        mimes: ['video/mp4'],
-        skip: 1,
-        skipmin: 5,
-        skipafter: 30,
-        minduration: 15,
-        maxduration: 60,
-        startdelay: 5,
-        minbitrate: 500,
-        maxbitrate: 2000,
-        w: 1024,
-        h: 640,
-        placement: INSTREAM_TYPE,
-      };
-      bidRequest.params.video = videoParams;
-      const request = spec.buildRequests([bidRequest], bidderRequest)[0];
-      const payload = JSON.parse(request.data);
-      expect(payload.imp[0].video).to.deep.equal(videoParams);
-    });
+      it('should ignore invalid/unexpected video params', function() {
+        const bidRequest = deepClone(instreamBidRequest);
+        // 1
+        const videoTest = {
+          skip: 1,
+          skipmin: 5,
+          skipafter: 30
+        }
+        const videoTestInvParam = Object.assign({}, videoTest);
+        videoTestInvParam.blah = 1;
+        bidRequest.params.video = videoTestInvParam;
+        let request = spec.buildRequests([bidRequest], {})[0];
+        let payload = JSON.parse(request.data);
+        expect(payload.imp[0].video.blah).not.to.exist;
+      });
 
-    it('should set video playerSize over video params', () => {
-      const bidRequest = deepClone(instreamBidRequest);
-      bidRequest.params.video = {
-        w: 1024, h: 640
-      }
-      const request = spec.buildRequests([bidRequest], bidderRequest)[0];
-      const payload = JSON.parse(request.data);
-      expect(payload.imp[0].video.h).equal(480);
-      expect(payload.imp[0].video.w).equal(640);
-    });
-
-    it('should ignore invalid/unexpected video params', function() {
-      const bidRequest = deepClone(instreamBidRequest);
-      // 1
-      const videoTest = {
-        skip: 1,
-        skipmin: 5,
-        skipafter: 30
-      }
-      const videoTestInvParam = Object.assign({}, videoTest);
-      videoTestInvParam.blah = 1;
-      bidRequest.params.video = videoTestInvParam;
-      let request = spec.buildRequests([bidRequest], {})[0];
-      let payload = JSON.parse(request.data);
-      expect(payload.imp[0].video.blah).not.to.exist;
-    });
-
-    it('should set video params for outstream', function() {
-      const bidRequest = deepClone(outstreamBidRequest);
-      bidRequest.params.video = videoParams;
-      const request = spec.buildRequests([bidRequest], {})[0];
-      const payload = JSON.parse(request.data);
-      expect(payload.imp[0].video).to.deep.equal({...{
-        mimes: ['video/mp4'],
-        placement: OUTSTREAM_TYPE,
-        w: bidRequest.mediaTypes.video.playerSize[0],
-        h: bidRequest.mediaTypes.video.playerSize[1],
-      },
-      ...videoParams});
-    });
-    //
-    it('should set video params for multi-format', function() {
-      const bidRequest = deepClone(multiFormatBidRequest);
-      bidRequest.params.video = videoParams;
-      const request = spec.buildRequests([bidRequest], {})[0];
-      const payload = JSON.parse(request.data);
-      const testVideoParams = Object.assign({
-        placement: OUTSTREAM_TYPE,
-        w: 640,
-        h: 480,
-        mimes: ['video/mp4'],
-      }, videoParams);
-      expect(payload.imp[0].video).to.deep.equal(testVideoParams);
-    });
+      it('should set video params for outstream', function() {
+        const bidRequest = deepClone(outstreamBidRequest);
+        bidRequest.params.video = videoParams;
+        const request = spec.buildRequests([bidRequest], {})[0];
+        const payload = JSON.parse(request.data);
+        expect(payload.imp[0].video).to.deep.equal({...{
+          mimes: ['video/mp4'],
+          placement: OUTSTREAM_TYPE,
+          w: bidRequest.mediaTypes.video.playerSize[0],
+          h: bidRequest.mediaTypes.video.playerSize[1],
+        },
+        ...videoParams});
+      });
+      //
+      it('should set video params for multi-format', function() {
+        const bidRequest = deepClone(multiFormatBidRequest);
+        bidRequest.params.video = videoParams;
+        const request = spec.buildRequests([bidRequest], {})[0];
+        const payload = JSON.parse(request.data);
+        const testVideoParams = Object.assign({
+          placement: OUTSTREAM_TYPE,
+          w: 640,
+          h: 480,
+          mimes: ['video/mp4'],
+        }, videoParams);
+        expect(payload.imp[0].video).to.deep.equal(testVideoParams);
+      });
+    }
 
     it('should add schain', function () {
       const schain = '{"ver":"1.0","complete":1,"nodes":[{"asi":"headerlift.com","sid":"xyz","hp":1}]}';
@@ -609,7 +615,9 @@ describe('Improve Digital Adapter Tests', function () {
       const request = JSON.parse(requests[0].data);
       expect(request.imp.length).to.equal(2);
       expect(request.imp[0].banner).to.exist;
-      expect(request.imp[1].video).to.exist;
+      if (FEATURES.VIDEO) {
+        expect(request.imp[1].video).to.exist;
+      }
     });
 
     it('should create one request per endpoint in a single request mode', function () {
@@ -1237,33 +1245,34 @@ describe('Improve Digital Adapter Tests', function () {
       });
     }
 
-    // Video
-    it('should return a well-formed instream video bid', function () {
-      const bids = spec.interpretResponse(serverResponseVideo, makeRequest(instreamBidderRequest));
-      expectMatch(bids, expectedBidInstreamVideo);
-    });
+    if (FEATURES.VIDEO) {
+      it('should return a well-formed instream video bid', function () {
+        const bids = spec.interpretResponse(serverResponseVideo, makeRequest(instreamBidderRequest));
+        expectMatch(bids, expectedBidInstreamVideo);
+      });
 
-    it('should return a well-formed outstream video bid', function () {
-      const bids = spec.interpretResponse(serverResponseVideo, makeRequest(outstreamBidderRequest));
-      expect(bids[0].renderer).to.exist;
-      expectMatch(bids, expectedBidOutstreamVideo);
-    });
+      it('should return a well-formed outstream video bid', function () {
+        const bids = spec.interpretResponse(serverResponseVideo, makeRequest(outstreamBidderRequest));
+        expect(bids[0].renderer).to.exist;
+        expectMatch(bids, expectedBidOutstreamVideo);
+      });
 
-    it('should return a well-formed outstream video bid for multi-format ad unit', function () {
-      const request = makeRequest(multiFormatBidderRequest);
-      const videoResponse = deepClone(serverResponseVideo);
-      let bids = spec.interpretResponse(videoResponse, request);
-      expect(bids[0].renderer).to.exist;
-      expectMatch(bids, expectedBidOutstreamVideo);
+      it('should return a well-formed outstream video bid for multi-format ad unit', function () {
+        const request = makeRequest(multiFormatBidderRequest);
+        const videoResponse = deepClone(serverResponseVideo);
+        let bids = spec.interpretResponse(videoResponse, request);
+        expect(bids[0].renderer).to.exist;
+        expectMatch(bids, expectedBidOutstreamVideo);
 
-      videoResponse.body.seatbid[0].bid[0].adm = '<vAst';
-      bids = spec.interpretResponse(videoResponse, request);
-      expect(bids[0].mediaType).to.equal(VIDEO);
+        videoResponse.body.seatbid[0].bid[0].adm = '<vAst';
+        bids = spec.interpretResponse(videoResponse, request);
+        expect(bids[0].mediaType).to.equal(VIDEO);
 
-      videoResponse.body.seatbid[0].bid[0].adm = '<?xml';
-      bids = spec.interpretResponse(videoResponse, request);
-      expect(bids[0].mediaType).to.equal(VIDEO);
-    });
+        videoResponse.body.seatbid[0].bid[0].adm = '<?xml';
+        bids = spec.interpretResponse(videoResponse, request);
+        expect(bids[0].mediaType).to.equal(VIDEO);
+      });
+    }
   });
 
   describe('getUserSyncs', function () {

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -16,6 +16,7 @@ import 'modules/schain.js';
 import {deepClone} from 'src/utils.js';
 import {syncAddFPDToBidderRequest} from '../../helpers/fpd.js';
 import {hook} from '../../../src/hook.js';
+import features from 'core-js-pure/features/index.js';
 
 const DEFAULT_SYNC = SYNC_URL + '?ph=' + DEFAULT_PH;
 
@@ -950,12 +951,14 @@ describe('OpenxRtbAdapter', function () {
       });
     });
 
-    context('video', function () {
-      it('should send bid request with a mediaTypes specified with video type', function () {
-        const request = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);
-        expect(request[1].data.imp[0]).to.have.any.keys(VIDEO);
+    if (features.VIDEO) {
+      context('video', function () {
+        it('should send bid request with a mediaTypes specified with video type', function () {
+          const request = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);
+          expect(request[1].data.imp[0]).to.have.any.keys(VIDEO);
+        });
       });
-    });
+    }
 
     it.skip('should send ad unit ids when any are defined', function () {
       const bidRequestsWithUnitIds = [{
@@ -1276,56 +1279,58 @@ describe('OpenxRtbAdapter', function () {
       });
     });
 
-    context('when the response is a video', function() {
-      beforeEach(function () {
-        bidRequestConfigs = [{
-          bidder: 'openx',
-          params: {
-            unit: '12345678',
-            delDomain: 'test-del-domain'
-          },
-          adUnitCode: 'adunit-code',
-          mediaTypes: {
-            video: {
-              playerSize: [[640, 360], [854, 480]],
+    if (FEATURES.VIDEO) {
+      context('when the response is a video', function() {
+        beforeEach(function () {
+          bidRequestConfigs = [{
+            bidder: 'openx',
+            params: {
+              unit: '12345678',
+              delDomain: 'test-del-domain'
             },
-          },
-          bidId: 'test-bid-id',
-          bidderRequestId: 'test-bidder-request-id',
-          auctionId: 'test-auction-id'
-        }];
+            adUnitCode: 'adunit-code',
+            mediaTypes: {
+              video: {
+                playerSize: [[640, 360], [854, 480]],
+              },
+            },
+            bidId: 'test-bid-id',
+            bidderRequestId: 'test-bidder-request-id',
+            auctionId: 'test-auction-id'
+          }];
 
-        bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
+          bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
 
-        bidResponse = {
-          seatbid: [{
-            bid: [{
-              impid: 'test-bid-id',
-              price: 2,
-              w: 854,
-              h: 480,
-              crid: 'test-creative-id',
-              dealid: 'test-deal-id',
-              adm: 'test-ad-markup',
-            }]
-          }],
-          cur: 'AUS'
-        };
+          bidResponse = {
+            seatbid: [{
+              bid: [{
+                impid: 'test-bid-id',
+                price: 2,
+                w: 854,
+                h: 480,
+                crid: 'test-creative-id',
+                dealid: 'test-deal-id',
+                adm: 'test-ad-markup',
+              }]
+            }],
+            cur: 'AUS'
+          };
+        });
+
+        it('should return the proper mediaType', function () {
+          bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+          expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
+        });
+
+        it('should return the proper mediaType', function () {
+          const winUrl = 'https//my.win.url';
+          bidResponse.seatbid[0].bid[0].nurl = winUrl
+          bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+
+          expect(bid.vastUrl).to.equal(winUrl);
+        });
       });
-
-      it('should return the proper mediaType', function () {
-        bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
-        expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
-      });
-
-      it('should return the proper mediaType', function () {
-        const winUrl = 'https//my.win.url';
-        bidResponse.seatbid[0].bid[0].nurl = winUrl
-        bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
-
-        expect(bid.vastUrl).to.equal(winUrl);
-      });
-    });
+    }
 
     context('when the response contains FLEDGE interest groups config', function() {
       let response;

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -705,51 +705,53 @@ describe('S2S Adapter', function () {
       expect(server.requests.length).to.equal(0);
     });
 
-    it('should add outstream bc renderer exists on mediatype', function () {
-      config.setConfig({ s2sConfig: CONFIG });
+    if (FEATURES.VIDEO) {
+      it('should add outstream bc renderer exists on mediatype', function () {
+        config.setConfig({ s2sConfig: CONFIG });
 
-      adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+        adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
 
-      const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.imp[0].banner).to.exist;
-      expect(requestBid.imp[0].video).to.exist;
-    });
+        const requestBid = JSON.parse(server.requests[0].requestBody);
+        expect(requestBid.imp[0].banner).to.exist;
+        expect(requestBid.imp[0].video).to.exist;
+      });
 
-    it('should default video placement if not defined and instream', function () {
-      let ortb2Config = utils.deepClone(CONFIG);
-      ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
+      it('should default video placement if not defined and instream', function () {
+        let ortb2Config = utils.deepClone(CONFIG);
+        ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({ s2sConfig: ortb2Config });
+        config.setConfig({ s2sConfig: ortb2Config });
 
-      let videoBid = utils.deepClone(VIDEO_REQUEST);
-      videoBid.ad_units[0].mediaTypes.video.context = 'instream';
-      adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
+        let videoBid = utils.deepClone(VIDEO_REQUEST);
+        videoBid.ad_units[0].mediaTypes.video.context = 'instream';
+        adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
 
-      const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.imp[0].banner).to.not.exist;
-      expect(requestBid.imp[0].video).to.exist;
-      expect(requestBid.imp[0].video.placement).to.equal(1);
-    });
+        const requestBid = JSON.parse(server.requests[0].requestBody);
+        expect(requestBid.imp[0].banner).to.not.exist;
+        expect(requestBid.imp[0].video).to.exist;
+        expect(requestBid.imp[0].video.placement).to.equal(1);
+      });
 
-    it('converts video mediaType properties into openRTB format', function () {
-      let ortb2Config = utils.deepClone(CONFIG);
-      ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
+      it('converts video mediaType properties into openRTB format', function () {
+        let ortb2Config = utils.deepClone(CONFIG);
+        ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';
 
-      config.setConfig({ s2sConfig: ortb2Config });
+        config.setConfig({ s2sConfig: ortb2Config });
 
-      let videoBid = utils.deepClone(VIDEO_REQUEST);
-      videoBid.ad_units[0].mediaTypes.video.context = 'instream';
-      adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
+        let videoBid = utils.deepClone(VIDEO_REQUEST);
+        videoBid.ad_units[0].mediaTypes.video.context = 'instream';
+        adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
 
-      const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.imp[0].banner).to.not.exist;
-      expect(requestBid.imp[0].video).to.exist;
-      expect(requestBid.imp[0].video.placement).to.equal(1);
-      expect(requestBid.imp[0].video.w).to.equal(640);
-      expect(requestBid.imp[0].video.h).to.equal(480);
-      expect(requestBid.imp[0].video.playerSize).to.be.undefined;
-      expect(requestBid.imp[0].video.context).to.be.undefined;
-    });
+        const requestBid = JSON.parse(server.requests[0].requestBody);
+        expect(requestBid.imp[0].banner).to.not.exist;
+        expect(requestBid.imp[0].video).to.exist;
+        expect(requestBid.imp[0].video.placement).to.equal(1);
+        expect(requestBid.imp[0].video.w).to.equal(640);
+        expect(requestBid.imp[0].video.h).to.equal(480);
+        expect(requestBid.imp[0].video.playerSize).to.be.undefined;
+        expect(requestBid.imp[0].video.context).to.be.undefined;
+      });
+    }
 
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
@@ -2615,28 +2617,30 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('dealId', 'test-dealid');
     });
 
-    it('should pass through default adserverTargeting if present in bidObject for video request', function () {
-      config.setConfig({ s2sConfig: CONFIG });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB);
-      const targetingTestData = {
-        hb_cache_path: '/cache',
-        hb_cache_host: 'prebid-cache.testurl.com'
-      };
+    if (FEATURES.VIDEO) {
+      it('should pass through default adserverTargeting if present in bidObject for video request', function () {
+        config.setConfig({ s2sConfig: CONFIG });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB);
+        const targetingTestData = {
+          hb_cache_path: '/cache',
+          hb_cache_host: 'prebid-cache.testurl.com'
+        };
 
-      cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.targeting = targetingTestData
-      });
-      adapter.callBids(VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+        cacheResponse.seatbid.forEach(item => {
+          item.bid[0].ext.prebid.targeting = targetingTestData
+        });
+        adapter.callBids(VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
 
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('adserverTargeting');
-      expect(response.adserverTargeting).to.deep.equal({
-        'hb_cache_path': '/cache',
-        'hb_cache_host': 'prebid-cache.testurl.com'
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+        expect(response).to.have.property('adserverTargeting');
+        expect(response.adserverTargeting).to.deep.equal({
+          'hb_cache_path': '/cache',
+          'hb_cache_host': 'prebid-cache.testurl.com'
+        });
       });
-    });
+    }
 
     it('should set the bidResponse currency to whats in the PBS response', function () {
       adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
@@ -2752,173 +2756,175 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('ttl', 30);
     });
 
-    it('handles OpenRTB video responses', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
-      });
-      config.setConfig({ s2sConfig });
-
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
-
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(RESPONSE_OPENRTB_VIDEO));
-
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('statusMessage', 'Bid available');
-      expect(response).to.have.property('vastXml', RESPONSE_OPENRTB_VIDEO.seatbid[0].bid[0].adm);
-      expect(response).to.have.property('mediaType', 'video');
-      expect(response).to.have.property('bidderCode', 'appnexus');
-      expect(response).to.have.property('requestId', '123');
-      expect(response).to.have.property('cpm', 10);
-    });
-
-    it('handles response cache from ext.prebid.cache.vastXml', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
-      });
-      config.setConfig({ s2sConfig });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
-      cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.cache = {
-          vastXml: {
-            cacheId: 'abcd1234',
-            url: 'https://prebid-cache.net/cache?uuid=abcd1234'
+    if (FEATURES.VIDEO) {
+      it('handles OpenRTB video responses', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
           }
-        }
+        });
+        config.setConfig({ s2sConfig });
+
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
+
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(RESPONSE_OPENRTB_VIDEO));
+
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+        expect(response).to.have.property('statusMessage', 'Bid available');
+        expect(response).to.have.property('vastXml', RESPONSE_OPENRTB_VIDEO.seatbid[0].bid[0].adm);
+        expect(response).to.have.property('mediaType', 'video');
+        expect(response).to.have.property('bidderCode', 'appnexus');
+        expect(response).to.have.property('requestId', '123');
+        expect(response).to.have.property('cpm', 10);
       });
 
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
+      it('handles response cache from ext.prebid.cache.vastXml', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+          }
+        });
+        config.setConfig({ s2sConfig });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
+        cacheResponse.seatbid.forEach(item => {
+          item.bid[0].ext.prebid.cache = {
+            vastXml: {
+              cacheId: 'abcd1234',
+              url: 'https://prebid-cache.net/cache?uuid=abcd1234'
+            }
+          }
+        });
 
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
 
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
 
-      expect(response).to.have.property('statusMessage', 'Bid available');
-      expect(response).to.have.property('videoCacheKey', 'abcd1234');
-      expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=abcd1234');
-    });
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
 
-    it('add adserverTargeting object to bids when ext.prebid.targeting is defined', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
-      });
-      config.setConfig({ s2sConfig });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
-      const targetingTestData = {
-        hb_cache_path: '/cache',
-        hb_cache_host: 'prebid-cache.testurl.com'
-      };
-
-      cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.targeting = targetingTestData
-      });
-
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
-
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
-
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
-
-      expect(response).to.have.property('adserverTargeting');
-      expect(response.adserverTargeting).to.deep.equal({
-        'hb_cache_path': '/cache',
-        'hb_cache_host': 'prebid-cache.testurl.com'
-      });
-    });
-
-    it('handles response cache from ext.prebid.targeting', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
-      });
-      config.setConfig({ s2sConfig });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
-      cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.targeting = {
-          hb_uuid: 'a5ad3993',
-          hb_cache_host: 'prebid-cache.net',
-          hb_cache_path: '/cache'
-        }
+        expect(response).to.have.property('statusMessage', 'Bid available');
+        expect(response).to.have.property('videoCacheKey', 'abcd1234');
+        expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=abcd1234');
       });
 
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
-
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
-
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
-
-      expect(response).to.have.property('statusMessage', 'Bid available');
-      expect(response).to.have.property('videoCacheKey', 'a5ad3993');
-      expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=a5ad3993');
-    });
-
-    it('handles response cache from ext.prebid.targeting with wurl', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
-      });
-      config.setConfig({ s2sConfig });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
-      cacheResponse.seatbid.forEach(item => {
-        item.bid[0].ext.prebid.events = {
-          win: 'https://wurl.com?a=1&b=2'
+      it('add adserverTargeting object to bids when ext.prebid.targeting is defined', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+          }
+        });
+        config.setConfig({ s2sConfig });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
+        const targetingTestData = {
+          hb_cache_path: '/cache',
+          hb_cache_host: 'prebid-cache.testurl.com'
         };
-        item.bid[0].ext.prebid.targeting = {
-          hb_uuid: 'a5ad3993',
-          hb_cache_host: 'prebid-cache.net',
-          hb_cache_path: '/cache'
-        }
+
+        cacheResponse.seatbid.forEach(item => {
+          item.bid[0].ext.prebid.targeting = targetingTestData
+        });
+
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
+
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+
+        expect(response).to.have.property('adserverTargeting');
+        expect(response.adserverTargeting).to.deep.equal({
+          'hb_cache_path': '/cache',
+          'hb_cache_host': 'prebid-cache.testurl.com'
+        });
       });
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
 
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+      it('handles response cache from ext.prebid.targeting', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+          }
+        });
+        config.setConfig({ s2sConfig });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
+        cacheResponse.seatbid.forEach(item => {
+          item.bid[0].ext.prebid.targeting = {
+            hb_uuid: 'a5ad3993',
+            hb_cache_host: 'prebid-cache.net',
+            hb_cache_path: '/cache'
+          }
+        });
 
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('pbsBidId', '654321');
-    });
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
 
-    it('add request property pbsBidId with ext.prebid.bidid value', function () {
-      const s2sConfig = Object.assign({}, CONFIG, {
-        endpoint: {
-          p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
-        }
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+
+        expect(response).to.have.property('statusMessage', 'Bid available');
+        expect(response).to.have.property('videoCacheKey', 'a5ad3993');
+        expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=a5ad3993');
       });
-      config.setConfig({ s2sConfig });
-      const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
 
-      const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
-      s2sVidRequest.s2sConfig = s2sConfig;
+      it('handles response cache from ext.prebid.targeting with wurl', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+          }
+        });
+        config.setConfig({ s2sConfig });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
+        cacheResponse.seatbid.forEach(item => {
+          item.bid[0].ext.prebid.events = {
+            win: 'https://wurl.com?a=1&b=2'
+          };
+          item.bid[0].ext.prebid.targeting = {
+            hb_uuid: 'a5ad3993',
+            hb_cache_host: 'prebid-cache.net',
+            hb_cache_path: '/cache'
+          }
+        });
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
 
-      adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
-      server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
 
-      sinon.assert.calledOnce(addBidResponse);
-      const response = addBidResponse.firstCall.args[1];
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+        expect(response).to.have.property('pbsBidId', '654321');
+      });
 
-      expect(response).to.have.property('pbsBidId', '654321');
-    });
+      it('add request property pbsBidId with ext.prebid.bidid value', function () {
+        const s2sConfig = Object.assign({}, CONFIG, {
+          endpoint: {
+            p1Consent: 'https://prebidserverurl/openrtb2/auction?querystring=param'
+          }
+        });
+        config.setConfig({ s2sConfig });
+        const cacheResponse = utils.deepClone(RESPONSE_OPENRTB_VIDEO);
+
+        const s2sVidRequest = utils.deepClone(VIDEO_REQUEST);
+        s2sVidRequest.s2sConfig = s2sConfig;
+
+        adapter.callBids(s2sVidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        server.requests[0].respond(200, {}, JSON.stringify(cacheResponse));
+
+        sinon.assert.calledOnce(addBidResponse);
+        const response = addBidResponse.firstCall.args[1];
+
+        expect(response).to.have.property('pbsBidId', '654321');
+      });
+    }
 
     if (FEATURES.NATIVE) {
       it('handles OpenRTB native responses', function () {

--- a/test/spec/modules/sizeMappingV2_spec.js
+++ b/test/spec/modules/sizeMappingV2_spec.js
@@ -445,6 +445,9 @@ describe('sizeMappingV2', function () {
     });
 
     describe('video mediaTypes checks', function () {
+      if (!FEATURES.VIDEO) {
+        return;
+      }
       beforeEach(function () {
         sinon.spy(adUnitSetupChecks, 'validateVideoMediaType');
       });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1607,7 +1607,9 @@ describe('adapterManager tests', function () {
         const alias = 'aliasBidder';
         adapterManager.aliasBidAdapter(CODE, alias);
         expect(adapterManager.bidderRegistry).to.have.property(alias);
-        expect(adapterManager.videoAdapters).to.include(alias);
+        if (FEATURES.VIDEO) {
+          expect(adapterManager.videoAdapters).to.include(alias);
+        }
       });
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2110,7 +2110,9 @@ describe('Unit: Prebid Module', function () {
               adUnits: fullAdUnit
             });
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
+            if (FEATURES.VIDEO) {
+              expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
+            }
             expect(auctionArgs.adUnits[0].mediaTypes.native.image.sizes).to.deep.equal([150, 150]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.icon.sizes).to.deep.equal([75, 75]);
             expect(auctionArgs.adUnits[0].mediaTypes.native.image.aspect_ratios).to.deep.equal([140, 140]);
@@ -2140,7 +2142,9 @@ describe('Unit: Prebid Module', function () {
               adUnits: noOptnlFieldAdUnit
             });
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[300, 250]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+            if (FEATURES.VIDEO) {
+              expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+            }
 
             let mixedAdUnit = [{
               code: 'test3',
@@ -2163,24 +2167,28 @@ describe('Unit: Prebid Module', function () {
               adUnits: mixedAdUnit
             });
             expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[400, 350]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+            if (FEATURES.VIDEO) {
+              expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+            }
 
-            let altVideoPlayerSize = [{
-              code: 'test4',
-              bids: [],
-              sizes: [[600, 600]],
-              mediaTypes: {
-                video: {
-                  playerSize: [640, 480]
+            if (FEATURES.VIDEO) {
+              let altVideoPlayerSize = [{
+                code: 'test4',
+                bids: [],
+                sizes: [[600, 600]],
+                mediaTypes: {
+                  video: {
+                    playerSize: [640, 480]
+                  }
                 }
-              }
-            }];
-            $$PREBID_GLOBAL$$.requestBids({
-              adUnits: altVideoPlayerSize
-            });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+              }];
+              $$PREBID_GLOBAL$$.requestBids({
+                adUnits: altVideoPlayerSize
+              });
+              expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[640, 480]]);
+              expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.deep.equal([[640, 480]]);
+              expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+            }
           });
 
           it('should normalize adUnit.sizes and adUnit.mediaTypes.banner.sizes', function () {
@@ -2285,41 +2293,43 @@ describe('Unit: Prebid Module', function () {
             expect(auctionArgs.adUnits[0].mediaTypes.banner).to.be.undefined;
             assert.ok(logErrorSpy.calledWith('Detected a mediaTypes.banner object without a proper sizes field.  Please ensure the sizes are listed like: [[300, 250], ...].  Removing invalid mediaTypes.banner object from request.'));
 
-            let badVideo1 = [{
-              code: 'testb2',
-              bids: [],
-              sizes: [[600, 600]],
-              mediaTypes: {
-                video: {
-                  playerSize: ['600x400']
+            if (FEATURES.VIDEO) {
+              let badVideo1 = [{
+                code: 'testb2',
+                bids: [],
+                sizes: [[600, 600]],
+                mediaTypes: {
+                  video: {
+                    playerSize: ['600x400']
+                  }
                 }
-              }
-            }];
-            $$PREBID_GLOBAL$$.requestBids({
-              adUnits: badVideo1
-            });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
-            expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
-            assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
+              }];
+              $$PREBID_GLOBAL$$.requestBids({
+                adUnits: badVideo1
+              });
+              expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
+              expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
+              expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+              assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
 
-            let badVideo2 = [{
-              code: 'testb3',
-              bids: [],
-              sizes: [[600, 600]],
-              mediaTypes: {
-                video: {
-                  playerSize: [['300', '200']]
+              let badVideo2 = [{
+                code: 'testb3',
+                bids: [],
+                sizes: [[600, 600]],
+                mediaTypes: {
+                  video: {
+                    playerSize: [['300', '200']]
+                  }
                 }
-              }
-            }];
-            $$PREBID_GLOBAL$$.requestBids({
-              adUnits: badVideo2
-            });
-            expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
-            expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
-            expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
-            assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
+              }];
+              $$PREBID_GLOBAL$$.requestBids({
+                adUnits: badVideo2
+              });
+              expect(auctionArgs.adUnits[0].sizes).to.deep.equal([[600, 600]]);
+              expect(auctionArgs.adUnits[0].mediaTypes.video.playerSize).to.be.undefined;
+              expect(auctionArgs.adUnits[0].mediaTypes.video).to.exist;
+              assert.ok(logErrorSpy.calledWith('Detected incorrect configuration of mediaTypes.video.playerSize.  Please specify only one set of dimensions in a format like: [[640, 480]]. Removing invalid mediaTypes.video.playerSize property from request.'));
+            }
 
             if (FEATURES.NATIVE) {
               let badNativeImgSize = [{
@@ -3312,69 +3322,71 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('markWinningBidAsUsed', function () {
-    it('marks the bid object as used for the given adUnitCode/adId combination', function () {
-      // make sure the auction has "state" and does not reload the fixtures
-      const adUnitCode = '/19968336/header-bid-tag-0';
-      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
-      auction.getBidsReceived = function() { return bidsReceived.bids };
+  if (FEATURES.VIDEO) {
+    describe('markWinningBidAsUsed', function () {
+      it('marks the bid object as used for the given adUnitCode/adId combination', function () {
+        // make sure the auction has "state" and does not reload the fixtures
+        const adUnitCode = '/19968336/header-bid-tag-0';
+        const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+        auction.getBidsReceived = function() { return bidsReceived.bids };
 
-      // mark the bid and verify the state has changed to RENDERED
-      const winningBid = targeting.getWinningBids(adUnitCode)[0];
-      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: winningBid.adId });
-      const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
-        bid => bid.adId === winningBid.adId);
+        // mark the bid and verify the state has changed to RENDERED
+        const winningBid = targeting.getWinningBids(adUnitCode)[0];
+        $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: winningBid.adId });
+        const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
+          bid => bid.adId === winningBid.adId);
 
-      expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
-      resetAuction();
+        expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
+        resetAuction();
+      });
+
+      it('try and mark the bid object, but fail because we supplied the wrong adId', function () {
+        const adUnitCode = '/19968336/header-bid-tag-0';
+        const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+        auction.getBidsReceived = function() { return bidsReceived.bids };
+
+        const winningBid = targeting.getWinningBids(adUnitCode)[0];
+        $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: 'miss' });
+        const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
+          bid => bid.adId === winningBid.adId);
+
+        expect(markedBid.status).to.not.equal(CONSTANTS.BID_STATUS.RENDERED);
+        resetAuction();
+      });
+
+      it('marks the winning bid object as used for the given adUnitCode', function () {
+        // make sure the auction has "state" and does not reload the fixtures
+        const adUnitCode = '/19968336/header-bid-tag-0';
+        const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+        auction.getBidsReceived = function() { return bidsReceived.bids };
+
+        // mark the bid and verify the state has changed to RENDERED
+        const winningBid = targeting.getWinningBids(adUnitCode)[0];
+        $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode });
+        const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
+          bid => bid.adId === winningBid.adId);
+
+        expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
+        resetAuction();
+      });
+
+      it('marks a bid object as used for the given adId', function () {
+        // make sure the auction has "state" and does not reload the fixtures
+        const adUnitCode = '/19968336/header-bid-tag-0';
+        const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+        auction.getBidsReceived = function() { return bidsReceived.bids };
+
+        // mark the bid and verify the state has changed to RENDERED
+        const winningBid = targeting.getWinningBids(adUnitCode)[0];
+        $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adId: winningBid.adId });
+        const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
+          bid => bid.adId === winningBid.adId);
+
+        expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
+        resetAuction();
+      });
     });
-
-    it('try and mark the bid object, but fail because we supplied the wrong adId', function () {
-      const adUnitCode = '/19968336/header-bid-tag-0';
-      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
-      auction.getBidsReceived = function() { return bidsReceived.bids };
-
-      const winningBid = targeting.getWinningBids(adUnitCode)[0];
-      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode, adId: 'miss' });
-      const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
-        bid => bid.adId === winningBid.adId);
-
-      expect(markedBid.status).to.not.equal(CONSTANTS.BID_STATUS.RENDERED);
-      resetAuction();
-    });
-
-    it('marks the winning bid object as used for the given adUnitCode', function () {
-      // make sure the auction has "state" and does not reload the fixtures
-      const adUnitCode = '/19968336/header-bid-tag-0';
-      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
-      auction.getBidsReceived = function() { return bidsReceived.bids };
-
-      // mark the bid and verify the state has changed to RENDERED
-      const winningBid = targeting.getWinningBids(adUnitCode)[0];
-      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adUnitCode });
-      const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
-        bid => bid.adId === winningBid.adId);
-
-      expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
-      resetAuction();
-    });
-
-    it('marks a bid object as used for the given adId', function () {
-      // make sure the auction has "state" and does not reload the fixtures
-      const adUnitCode = '/19968336/header-bid-tag-0';
-      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
-      auction.getBidsReceived = function() { return bidsReceived.bids };
-
-      // mark the bid and verify the state has changed to RENDERED
-      const winningBid = targeting.getWinningBids(adUnitCode)[0];
-      $$PREBID_GLOBAL$$.markWinningBidAsUsed({ adId: winningBid.adId });
-      const markedBid = find($$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode).bids,
-        bid => bid.adId === winningBid.adId);
-
-      expect(markedBid.status).to.equal(CONSTANTS.BID_STATUS.RENDERED);
-      resetAuction();
-    });
-  });
+  }
 
   describe('setTargetingForAst', function () {
     let targeting;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds support for disabling support for video ads and dropping related code from the final build, thus 
reducing bundle size. This is a spike and not a complete implementation, just the result of some 
time-boxed exploration on how this might be implemented.

## Results
Currently `zeus-neo` doesn't appear to make use of the `--disable` command line argument to Prebid's build. Combined with disabling support for native ads, this exploration on disabling video ads has shaved ~6K off of the final, compressed bundle size.

It's not much but every bit counts and there's more KB that can be saved with a more thorough analysis.

| `--disable` | Size on Disk | GZipped | Brotli compressed |
| --- | --- | --- | --- |
| Empty (current) | 278K | 90K | 75K |
| `NATIVE` | 262K | 85K | 71K |
| `NATIVE,VIDEO` | 255K | 83K | 69K |

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Jira ticket: [ZTB-1672](https://arcpublishing.atlassian.net/browse/ZTB-1672)