### PR TITLE
ZTB-1710: disable video in 8 files

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -462,7 +462,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
     handleBidResponse(adUnitCode, bid, (done) => {
       let bidResponse = getPreparedBidForAuction(bid);
 
-      if (bidResponse.mediaType === VIDEO) {
+      if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
         tryAddVideoBid(auctionInstance, bidResponse, done);
       } else {
         if (FEATURES.NATIVE && bidResponse.native != null && typeof bidResponse.native === 'object') {
@@ -573,28 +573,30 @@ export function addBidToAuction(auctionInstance, bidResponse) {
 
 // Video bids may fail if the cache is down, or there's trouble on the network.
 function tryAddVideoBid(auctionInstance, bidResponse, afterBidAdded, {index = auctionManager.index} = {}) {
-  let addBid = true;
+  if (FEATURES.VIDEO) {
+    let addBid = true;
 
-  const videoMediaType = deepAccess(
-    index.getMediaTypes({
-      requestId: bidResponse.originalRequestId || bidResponse.requestId,
-      transactionId: bidResponse.transactionId
-    }), 'video');
-  const context = videoMediaType && deepAccess(videoMediaType, 'context');
-  const useCacheKey = videoMediaType && deepAccess(videoMediaType, 'useCacheKey');
+    const videoMediaType = deepAccess(
+      index.getMediaTypes({
+        requestId: bidResponse.originalRequestId || bidResponse.requestId,
+        transactionId: bidResponse.transactionId
+      }), 'video');
+    const context = videoMediaType && deepAccess(videoMediaType, 'context');
+    const useCacheKey = videoMediaType && deepAccess(videoMediaType, 'useCacheKey');
 
-  if (config.getConfig('cache.url') && (useCacheKey || context !== OUTSTREAM)) {
-    if (!bidResponse.videoCacheKey || config.getConfig('cache.ignoreBidderCacheKey')) {
-      addBid = false;
-      callPrebidCache(auctionInstance, bidResponse, afterBidAdded, videoMediaType);
-    } else if (!bidResponse.vastUrl) {
-      logError('videoCacheKey specified but not required vastUrl for video bid');
-      addBid = false;
+    if (config.getConfig('cache.url') && (useCacheKey || context !== OUTSTREAM)) {
+      if (!bidResponse.videoCacheKey || config.getConfig('cache.ignoreBidderCacheKey')) {
+        addBid = false;
+        callPrebidCache(auctionInstance, bidResponse, afterBidAdded, videoMediaType);
+      } else if (!bidResponse.vastUrl) {
+        logError('videoCacheKey specified but not required vastUrl for video bid');
+        addBid = false;
+      }
     }
-  }
-  if (addBid) {
-    addBidToAuction(auctionInstance, bidResponse);
-    afterBidAdded();
+    if (addBid) {
+      addBidToAuction(auctionInstance, bidResponse);
+      afterBidAdded();
+    }
   }
 }
 
@@ -609,7 +611,7 @@ const addLegacyFieldsIfNeeded = (bidResponse) => {
   }
 }
 
-const storeInCache = (batch) => {
+const _storeInCache = (batch) => {
   store(batch.map(entry => entry.bidResponse), function (error, cacheIds) {
     cacheIds.forEach((cacheId, i) => {
       const { auctionInstance, bidResponse, afterBidAdded } = batch[i];
@@ -635,6 +637,8 @@ const storeInCache = (batch) => {
     });
   });
 };
+
+const storeInCache = FEATURES.VIDEO ? _storeInCache : () => {};
 
 let batchSize, batchTimeout;
 config.getConfig('cache', (cacheConfig) => {
@@ -771,7 +775,7 @@ function setupBidTargeting(bidObject) {
  */
 export function getMediaTypeGranularity(mediaType, mediaTypes, mediaTypePriceGranularity) {
   if (mediaType && mediaTypePriceGranularity) {
-    if (mediaType === VIDEO) {
+    if (FEATURES.VIDEO && mediaType === VIDEO) {
       const context = deepAccess(mediaTypes, `${VIDEO}.context`, 'instream');
       if (mediaTypePriceGranularity[`${VIDEO}-${context}`]) {
         return mediaTypePriceGranularity[`${VIDEO}-${context}`];
@@ -880,7 +884,7 @@ export function getStandardBidderSettings(mediaType, bidderCode) {
     standardSettings[CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING] = defaultAdserverTargeting();
   }
 
-  if (mediaType === 'video') {
+  if (FEATURES.VIDEO && mediaType === 'video') {
     const adserverTargeting = standardSettings[CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].slice();
     standardSettings[CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING] = adserverTargeting;
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -232,21 +232,23 @@ describe('auctionmanager.js', function () {
       assert.deepEqual(response, expected);
     });
 
-    it('No bidder level configuration defined - default for video', function () {
-      config.setConfig({
-        cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache'
-        }
-      });
-      $$PREBID_GLOBAL$$.bidderSettings = {};
-      let videoBid = utils.deepClone(bid);
-      videoBid.mediaType = 'video';
-      videoBid.videoCacheKey = 'abc123def';
+    if (FEATURES.VIDEO) {
+      it('No bidder level configuration defined - default for video', function () {
+        config.setConfig({
+          cache: {
+            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+          }
+        });
+        $$PREBID_GLOBAL$$.bidderSettings = {};
+        let videoBid = utils.deepClone(bid);
+        videoBid.mediaType = 'video';
+        videoBid.videoCacheKey = 'abc123def';
 
-      let expected = getDefaultExpected(videoBid);
-      let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
-      assert.deepEqual(response, expected);
-    });
+        let expected = getDefaultExpected(videoBid);
+        let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
+        assert.deepEqual(response, expected);
+      });
+    }
 
     it('Custom configuration for all bidders', function () {
       $$PREBID_GLOBAL$$.bidderSettings =
@@ -311,17 +313,18 @@ describe('auctionmanager.js', function () {
       assert.deepEqual(response, expected);
     });
 
-    it('Custom configuration for all bidders with video bid', function () {
-      config.setConfig({
-        cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache'
-        }
-      });
-      let videoBid = utils.deepClone(bid);
-      videoBid.mediaType = 'video';
-      videoBid.videoCacheKey = 'abc123def';
+    if (FEATURES.VIDEO) {
+      it('Custom configuration for all bidders with video bid', function () {
+        config.setConfig({
+          cache: {
+            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+          }
+        });
+        let videoBid = utils.deepClone(bid);
+        videoBid.mediaType = 'video';
+        videoBid.videoCacheKey = 'abc123def';
 
-      $$PREBID_GLOBAL$$.bidderSettings =
+        $$PREBID_GLOBAL$$.bidderSettings =
       {
         standard: {
           adserverTargeting: [
@@ -387,11 +390,12 @@ describe('auctionmanager.js', function () {
         }
       };
 
-      let expected = getDefaultExpected(videoBid);
+        let expected = getDefaultExpected(videoBid);
 
-      let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
-      assert.deepEqual(response, expected);
-    });
+        let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
+        assert.deepEqual(response, expected);
+      });
+    }
 
     it('Custom configuration for one bidder', function () {
       $$PREBID_GLOBAL$$.bidderSettings =
@@ -1385,63 +1389,65 @@ describe('auctionmanager.js', function () {
   }
 
   describe('getMediaTypeGranularity', function () {
-    it('video', function () {
-      let mediaTypes = { video: {id: '1'} };
+    if (FEATURES.VIDEO) {
+      it('video', function () {
+        let mediaTypes = { video: {id: '1'} };
 
-      // mediaType is video and video.context is undefined
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        // mediaType is video and video.context is undefined
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      expect(getMediaTypeGranularity('video', {}, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
-      ``
-      expect(getMediaTypeGranularity('video', undefined, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        expect(getMediaTypeGranularity('video', {}, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
+        ``
+        expect(getMediaTypeGranularity('video', undefined, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      // also when mediaTypes.video is undefined
-      mediaTypes = { banner: {} };
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
+        // also when mediaTypes.video is undefined
+        mediaTypes = { banner: {} };
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
 
-      // also when mediaTypes is undefined
-      expect(getMediaTypeGranularity('video', {}, {
-        banner: 'low',
-        video: 'medium'
-      })).to.equal('medium');
-    });
+        // also when mediaTypes is undefined
+        expect(getMediaTypeGranularity('video', {}, {
+          banner: 'low',
+          video: 'medium'
+        })).to.equal('medium');
+      });
 
-    it('video-outstream', function () {
-      let mediaTypes = { video: { context: 'outstream' } };
+      it('video-outstream', function () {
+        let mediaTypes = { video: { context: 'outstream' } };
 
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        'banner': 'low', 'video': 'medium', 'video-outstream': 'high'
-      })).to.equal('high');
-    });
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          'banner': 'low', 'video': 'medium', 'video-outstream': 'high'
+        })).to.equal('high');
+      });
 
-    it('video-instream', function () {
-      let mediaTypes = { video: { context: 'instream' } };
+      it('video-instream', function () {
+        let mediaTypes = { video: { context: 'instream' } };
 
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low', video: 'medium', 'video-instream': 'high'
-      })).to.equal('high');
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low', video: 'medium', 'video-instream': 'high'
+        })).to.equal('high');
 
-      // fall back to video if video-instream not found
-      expect(getMediaTypeGranularity('video', mediaTypes, {
-        banner: 'low', video: 'medium'
-      })).to.equal('medium');
+        // fall back to video if video-instream not found
+        expect(getMediaTypeGranularity('video', mediaTypes, {
+          banner: 'low', video: 'medium'
+        })).to.equal('medium');
 
-      expect(getMediaTypeGranularity('video', {mediaTypes: {banner: {}}}, {
-        banner: 'low', video: 'medium'
-      })).to.equal('medium');
-    });
+        expect(getMediaTypeGranularity('video', {mediaTypes: {banner: {}}}, {
+          banner: 'low', video: 'medium'
+        })).to.equal('medium');
+      });
+    }
 
     it('native', function () {
       expect(getMediaTypeGranularity('native', {native: {}}, {
@@ -1543,34 +1549,36 @@ describe('auctionmanager.js', function () {
       });
     })
 
-    it('should call auction done after prebid cache is complete for mediaType video', function() {
-      bids[0].mediaType = 'video';
-      let bids1 = [mockBid({ bidderCode: BIDDER_CODE1 })];
+    if (FEATURES.VIDEO) {
+      it('should call auction done after prebid cache is complete for mediaType video', function() {
+        bids[0].mediaType = 'video';
+        let bids1 = [mockBid({ bidderCode: BIDDER_CODE1 })];
 
-      let opts = {
-        mediaType: {
-          video: {
-            context: 'instream',
-            playerSize: [640, 480],
-          },
-        }
-      };
-      bidRequests = [
-        mockBidRequest(bids[0], opts),
-        mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
-      ];
+        let opts = {
+          mediaType: {
+            video: {
+              context: 'instream',
+              playerSize: [640, 480],
+            },
+          }
+        };
+        bidRequests = [
+          mockBidRequest(bids[0], opts),
+          mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
+        ];
 
-      let cbs = auctionCallbacks(doneSpy, auction);
-      cbs.addBidResponse.call(bidRequests[0], ADUNIT_CODE, bids[0]);
-      cbs.adapterDone.call(bidRequests[0]);
-      cbs.addBidResponse.call(bidRequests[1], ADUNIT_CODE1, bids1[0]);
-      cbs.adapterDone.call(bidRequests[1]);
-      assert.equal(doneSpy.callCount, 0);
-      const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
-      const responseBody = `{"responses":[{"uuid":"${uuid}"}]}`;
-      server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
-      assert.equal(doneSpy.callCount, 1);
-    });
+        let cbs = auctionCallbacks(doneSpy, auction);
+        cbs.addBidResponse.call(bidRequests[0], ADUNIT_CODE, bids[0]);
+        cbs.adapterDone.call(bidRequests[0]);
+        cbs.addBidResponse.call(bidRequests[1], ADUNIT_CODE1, bids1[0]);
+        cbs.adapterDone.call(bidRequests[1]);
+        assert.equal(doneSpy.callCount, 0);
+        const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
+        const responseBody = `{"responses":[{"uuid":"${uuid}"}]}`;
+        server.requests[0].respond(200, { 'Content-Type': 'application/json' }, responseBody);
+        assert.equal(doneSpy.callCount, 1);
+      });
+    }
 
     it('should convert cpm to number', () => {
       auction.addBidReceived = sinon.spy();


### PR DESCRIPTION
# Stats

| Bundle size on `master` | Bundle size after #5 | Bundle size after this PR | Cumulative Delta |
| --- | --- | --- | --- |
| 284,989 | 284,899 | 281,900 | 3,089 |

## Summary

Found some video-specific code that could be shaken out of the final build in `auction.js`. Subsequently broke 5 tests which were easy fixes, as they could simply be ignored when video is disabled.