### PR TITLE
ZTB-1713: disable video in 8 files (round 4)

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -599,7 +599,7 @@ export function isValid(adUnitCode, bid, {index = auctionManager.index} = {}) {
     logError(errorMessage('Native bid missing some required properties.'));
     return false;
   }
-  if (bid.mediaType === 'video' && !isValidVideoBid(bid, {index})) {
+  if (FEATURES.VIDEO && bid.mediaType === 'video' && !isValidVideoBid(bid, {index})) {
     logError(errorMessage(`Video bid does not have required vastUrl or renderer property`));
     return false;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -904,7 +904,7 @@ export function isValidMediaTypes(mediaTypes) {
     return false;
   }
 
-  if (mediaTypes.video && mediaTypes.video.context) {
+  if (FEATURES.VIDEO && mediaTypes.video && mediaTypes.video.context) {
     return includes(SUPPORTED_STREAM_TYPES, mediaTypes.video.context);
   }
 


### PR DESCRIPTION
# Stats

| Bundle size on `master` | Bundle size after #7 | Bundle size after this PR | Cumulative Delta |
| --- | --- | --- | --- |
| 284,989 | 280,781 |  280,143 | -4,846 |

## Summary

Analyzed the following files looking for video-specific code:

- adapters/bidderFactory.js
- fpd/enrichment.js
- fpd/rootDomain.js
- userSync.js
- utils.js
- video.js
- videoCache.js

Didn't find much in this batch.